### PR TITLE
Road Rash: update game-specific config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -913,7 +913,7 @@ static void cfg_create_ini()
             "\n"
             "; ROAD RASH\n"
             "[RoadRash]\n"
-            "adjmouse=true\n"
+            "fixchilds=1\n"
             "\n"
             "; Septerra Core\n"
             "[septerra]\n"


### PR DESCRIPTION
- remove `adjmouse=true` (as it is globally default anyway)
- add `fixchilds=1` (fixes #190)