### PR TITLE
rgb555 setting

### DIFF
--- a/inc/dd.h
+++ b/inc/dd.h
@@ -175,6 +175,7 @@ typedef struct CNCDDRAW
     SPEEDLIMITER ticks_limiter;
     SPEEDLIMITER flip_limiter;
     DWORD gui_thread_id;
+    BOOL rgb555;
 
 } CNCDDRAW;
 

--- a/src/config.c
+++ b/src/config.c
@@ -55,6 +55,7 @@ void cfg_load()
     g_ddraw->max_resolutions = cfg_get_int("max_resolutions", 0);
     g_ddraw->limit_bltfast = cfg_get_bool("limit_bltfast", FALSE);
     g_ddraw->opengl_core = cfg_get_bool("opengl_core", FALSE);
+    g_ddraw->rgb555 = cfg_get_bool("rgb555", FALSE);
     cfg_get_string("screenshotdir", ".\\Screenshots\\", g_ddraw->screenshot_dir, sizeof(g_ddraw->screenshot_dir));
 
     if (g_ddraw->locktopleft)
@@ -376,6 +377,7 @@ static void cfg_create_ini()
             "flipclear=false\n"
             "fixmousehook=false\n"
             "bpp=0\n"
+            "rgb555=false\n"
             "\n"
             "\n"
             "\n"

--- a/src/ddsurface.c
+++ b/src/ddsurface.c
@@ -1374,6 +1374,12 @@ HRESULT dd_CreateSurface(
                 dst_surface->bmi->bmiColors[i].rgbReserved = 0;
             }
         }
+        else if (dst_surface->bpp == 16 && g_ddraw->rgb555)
+        {
+            ((DWORD*)dst_surface->bmi->bmiColors)[0] = 0x7C00;
+            ((DWORD*)dst_surface->bmi->bmiColors)[1] = 0x03E0;
+            ((DWORD*)dst_surface->bmi->bmiColors)[2] = 0x001F;
+        }
         else if (dst_surface->bpp == 16)
         {
             ((DWORD*)dst_surface->bmi->bmiColors)[0] = 0xF800;

--- a/src/render_d3d9.c
+++ b/src/render_d3d9.c
@@ -129,7 +129,7 @@ BOOL d3d9_create()
             g_d3d9.params.PresentationInterval = g_ddraw->vsync ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;
             g_d3d9.params.BackBufferWidth = g_d3d9.params.Windowed ? 0 : g_ddraw->render.width;
             g_d3d9.params.BackBufferHeight = g_d3d9.params.Windowed ? 0 : g_ddraw->render.height;
-            g_d3d9.params.BackBufferFormat = g_d3d9.bits_per_pixel == 16 ? D3DFMT_R5G6B5 : D3DFMT_X8R8G8B8;
+            g_d3d9.params.BackBufferFormat = g_d3d9.bits_per_pixel == 16 ? (g_ddraw->rgb555 ? D3DFMT_A1R5G5B5 : D3DFMT_R5G6B5) : D3DFMT_X8R8G8B8;
             g_d3d9.params.BackBufferCount = 1;
 
             DWORD behavior_flags[] = {
@@ -174,7 +174,7 @@ BOOL d3d9_reset(BOOL windowed)
     g_d3d9.params.Windowed = windowed;
     g_d3d9.params.BackBufferWidth = windowed ? 0 : g_ddraw->render.width;
     g_d3d9.params.BackBufferHeight = windowed ? 0 : g_ddraw->render.height;
-    g_d3d9.params.BackBufferFormat = g_d3d9.bits_per_pixel == 16 ? D3DFMT_R5G6B5 : D3DFMT_X8R8G8B8;
+    g_d3d9.params.BackBufferFormat = g_d3d9.bits_per_pixel == 16 ? (g_ddraw->rgb555 ? D3DFMT_A1R5G5B5 : D3DFMT_R5G6B5) : D3DFMT_X8R8G8B8;
 
     if (g_d3d9.device && SUCCEEDED(IDirect3DDevice9_Reset(g_d3d9.device, &g_d3d9.params)))
     {
@@ -293,7 +293,7 @@ static BOOL d3d9_create_resources()
                 g_d3d9.tex_height,
                 1,
                 0,
-                g_ddraw->bpp == 16 ? D3DFMT_R5G6B5 : g_ddraw->bpp == 32 ? D3DFMT_X8R8G8B8 : D3DFMT_L8,
+                g_ddraw->bpp == 16 ? (g_ddraw->rgb555 ? D3DFMT_A1R5G5B5 : D3DFMT_R5G6B5) : g_ddraw->bpp == 32 ? D3DFMT_X8R8G8B8 : D3DFMT_L8,
                 D3DPOOL_MANAGED,
                 &g_d3d9.surface_tex[i],
                 0));

--- a/src/render_ogl.c
+++ b/src/render_ogl.c
@@ -245,6 +245,19 @@ static void ogl_create_textures(int width, int height)
                 g_ogl.surface_type = GL_UNSIGNED_BYTE,
                 0);
         }
+        else if (g_ddraw->bpp == 16 && g_ddraw->rgb555)
+        {
+            glTexImage2D(
+                GL_TEXTURE_2D,
+                0,
+                GL_RGB5_A1,
+                g_ogl.surface_tex_width,
+                g_ogl.surface_tex_height,
+                0,
+                g_ogl.surface_format = GL_BGRA,
+                g_ogl.surface_type = GL_UNSIGNED_SHORT_1_5_5_5_REV,
+                0);
+        }
         else if (g_ddraw->bpp == 16)
         {
             glTexImage2D(


### PR DESCRIPTION
This adds a new boolean setting `rgb555` that changes 16-bit rendering from the default rgb565 to rgb555. Currently only works for OpenGL and gdi (my attempts to use `D3DFMT_X1R5G5B5` for direct3d9 were unsuccessful).

Closes #198

[edit] Got it to work in direct3d9 by using `A1R5G5B5`, so it works in all renderers now.